### PR TITLE
refactor: move cmd out of root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ COPY /go.mod /go.mod
 RUN cd / && go mod download
 
 # Now copy the rest of the source and run the build.
-COPY . /
-RUN cd / && go build -o service
+COPY . /src
+RUN cd /src/cmd && go build -o service
 
 #:::
 #::: RUNTIME CONTAINER
@@ -23,9 +23,8 @@ RUN cd / && go build -o service
 FROM golang:${GO_VERSION}-buster
 
 RUN mkdir -p /usr/local/bin
-COPY --from=0 /service /service
+COPY --from=0 /src/cmd/service /service
 ENV PATH="/:/usr/local/bin:${PATH}"
 
 EXPOSE 5050
 WORKDIR "/"
-ENTRYPOINT [ "/service" ]

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ lint:
 	GOGC=75 golangci-lint run --concurrency 32 --deadline 4m ./...
 
 build:
-	go build
+	cd cmd && go build -o ../sync-service
 
 docker:
 	docker build -t iptestground/sync-service:edge -f Dockerfile .

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/testground/sync-service"
 	"github.com/testground/testground/pkg/cmd"
 	"github.com/testground/testground/pkg/logging"
 )
@@ -21,12 +22,12 @@ func run() error {
 	ctx, cancel := context.WithCancel(cmd.ProcessContext())
 	defer cancel()
 
-	redisHost := os.Getenv(EnvRedisHost)
+	redisHost := os.Getenv(sync.EnvRedisHost)
 	if redisHost == "" {
-		redisHost = DefaultRedisHost
+		redisHost = sync.DefaultRedisHost
 	}
 
-	service, err := NewRedisService(ctx, logging.S(), &RedisConfiguration{
+	service, err := sync.NewRedisService(ctx, logging.S(), &sync.RedisConfiguration{
 		Port: 6379,
 		Host: redisHost,
 	})
@@ -35,7 +36,7 @@ func run() error {
 	}
 	service.EnableBackgroundGC(nil)
 
-	srv, err := NewServer(service, 5050)
+	srv, err := sync.NewServer(service, 5050)
 	if err != nil {
 		return err
 	}

--- a/connection.go
+++ b/connection.go
@@ -1,4 +1,4 @@
-package main
+package sync
 
 import (
 	"context"

--- a/redis.go
+++ b/redis.go
@@ -1,4 +1,4 @@
-package main
+package sync
 
 import (
 	"context"

--- a/redis_consumer.go
+++ b/redis_consumer.go
@@ -1,4 +1,4 @@
-package main
+package sync
 
 import (
 	"fmt"

--- a/redis_gc.go
+++ b/redis_gc.go
@@ -1,4 +1,4 @@
-package main
+package sync
 
 import (
 	"time"

--- a/redis_state.go
+++ b/redis_state.go
@@ -1,4 +1,4 @@
-package main
+package sync
 
 import (
 	"context"

--- a/redis_test.go
+++ b/redis_test.go
@@ -1,4 +1,4 @@
-package main
+package sync
 
 import (
 	"context"

--- a/redis_topic.go
+++ b/redis_topic.go
@@ -1,4 +1,4 @@
-package main
+package sync
 
 import (
 	"context"

--- a/redis_workers.go
+++ b/redis_workers.go
@@ -1,4 +1,4 @@
-package main
+package sync
 
 import (
 	"fmt"

--- a/server.go
+++ b/server.go
@@ -1,4 +1,4 @@
-package main
+package sync
 
 import (
 	"context"

--- a/types.go
+++ b/types.go
@@ -1,4 +1,4 @@
-package main
+package sync
 
 import "context"
 


### PR DESCRIPTION
...so the package can be imported by external packages.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>