### PR TITLE
ci: docker publish edge version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,12 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.16
+      - uses: actions/checkout@v3
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3.2.0
         with:
           version: v1.37
           args: --concurrency 32 --deadline 4m

--- a/.github/workflows/docker-publish-edge.yml
+++ b/.github/workflows/docker-publish-edge.yml
@@ -1,0 +1,28 @@
+name: Publish (edge)
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    env:
+      ORGANIZATION: iptestground
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: "${{ env.ORGANIZATION }}/sync-service:edge"
+          file: ./Dockerfile
+          platforms: linux/arm64,linux/amd64


### PR DESCRIPTION
Publish docker containers to `iptestground/sync-service:edge` on merge to master.

Secrets are stored in the organization: https://github.com/organizations/testground/settings/secrets/actions